### PR TITLE
"Локальный поиск ПБО": использовать в сигнатуре целевой функции span

### DIFF
--- a/example/local_search/local_search.cbp
+++ b/example/local_search/local_search.cbp
@@ -69,6 +69,7 @@
 			<Option target="Debug" />
 			<Option target="Release" />
 		</Unit>
+		<Unit filename="../../include/saga/cpp20/span.hpp" />
 		<Unit filename="main.cpp">
 			<Option target="Debug" />
 			<Option target="Release" />

--- a/example/local_search/main.cpp
+++ b/example/local_search/main.cpp
@@ -96,7 +96,8 @@ int main(int argc, char * argv[])
     auto objective_impl = manager.at(objective_name);
     auto objective = [&](std::valarray<bool> const & arg)
     {
-        return objective_impl(std::begin(arg), arg.size());
+        saga::boolean_const_span s(arg.size() == 0 ? nullptr : std::addressof(arg[0]), arg.size());
+        return objective_impl(s);
     };
 
     std::mt19937 random_engine(std::time(nullptr));

--- a/example/local_search/plugin.hpp
+++ b/example/local_search/plugin.hpp
@@ -7,12 +7,17 @@
 #ifndef PLUGIN_HPP_INCLUDED
 #define PLUGIN_HPP_INCLUDED
 
+#include <saga/cpp20/span.hpp>
+
 #include <cstddef>
 #include <string>
 
 namespace saga
 {
-    using pseudo_boolean_objective_signature = double(bool const *, std::size_t);
+    using objective_value_type = double;
+    using boolean_const_span = saga::span<bool const>;
+
+    using pseudo_boolean_objective_signature = objective_value_type(boolean_const_span);
 
     class function_manager
     {

--- a/example/local_search/sample_library.cpp
+++ b/example/local_search/sample_library.cpp
@@ -10,9 +10,10 @@
 
 #include <algorithm>
 
-double manhattan_norm(bool const * ptr, std::size_t dim)
+saga::objective_value_type
+manhattan_norm(saga::boolean_const_span xs)
 {
-    return std::count(ptr, ptr+dim, true);
+    return static_cast<saga::objective_value_type>(std::count(xs.begin(), xs.end(), true));
 }
 
 class sample_library_registrar


### PR DESCRIPTION
вместо пары (указатель, размер)