### PR TITLE
saga::lcm защищён от UB, которое осталось в std::lcm

### DIFF
--- a/include/saga/numeric.hpp
+++ b/include/saga/numeric.hpp
@@ -300,7 +300,8 @@ namespace saga
         std::common_type_t<IntType1, IntType2>
         operator()(IntType1 lhs, IntType2 rhs) const
         {
-            return std::lcm(std::move(lhs), std::move(rhs));
+            using Result = std::common_type_t<IntType1, IntType2>;
+            return std::lcm(Result(std::move(lhs)), Result(std::move(rhs)));
         }
     };
 

--- a/tests/numeric.cpp
+++ b/tests/numeric.cpp
@@ -1506,6 +1506,6 @@ TEST_CASE("lcm : functional object")
 
     saga_test::property_checker <<[](Value1 const & lhs, Value1 const & rhs)
     {
-        REQUIRE(saga::lcm(lhs, Value2(rhs)) == std::lcm(lhs, Value2(rhs)));
+        REQUIRE(saga::lcm(lhs, Value2(rhs)) == std::lcm(Value2(lhs), Value2(rhs)));
     };
 }


### PR DESCRIPTION
(по крайней мере на GCC 9.2.0)

#953 