### PR TITLE
Исправление subrange_cursor::splice

### DIFF
--- a/include/saga/cursor/subrange.hpp
+++ b/include/saga/cursor/subrange.hpp
@@ -43,7 +43,7 @@ namespace saga
             return lhs.begin() == rhs.begin()
                     && lhs.end() == rhs.end()
                     && lhs.cur_old_ == rhs.cur_old_
-                    && rhs.last_old_ == rhs.last_old_;
+                    && lhs.last_old_ == rhs.last_old_;
         }
 
     public:
@@ -266,15 +266,19 @@ namespace saga
         ForwardCursor2
         rebase_cursor(ForwardCursor1 src, ForwardCursor2 dest, std::forward_iterator_tag)
         {
-            // Что если у src есть пройденная задняя часть?
-
-            auto const n_front = saga::cursor::size(src.dropped_front());
+            auto const n_before = saga::cursor::size(src.dropped_front());
+            auto const n_body = saga::cursor::size(src);
 
             auto const n_result = saga::cursor::size(dest);
 
-            assert(n_front <= n_result);
+            assert(n_before + n_body <= n_result);
 
-            return saga::cursor::drop_front_n(std::move(dest), n_front);
+            auto after = saga::cursor::drop_front_n(std::move(dest), n_before + n_body);
+            dest = after.dropped_front();
+            after.exhaust_back();
+            dest.splice(after);
+
+            return saga::cursor::drop_front_n(std::move(dest), n_before);
         }
 
         template <class ForwardCursor, class BidirectionalCursor>

--- a/include/saga/cursor/subrange.hpp
+++ b/include/saga/cursor/subrange.hpp
@@ -64,7 +64,7 @@ namespace saga
          , last_(this->last_old_)
          , back_(this->last_)
         {
-            this->tweak_back(typename std::iterator_traits<Sentinel>::iterator_category{});
+            this->tweak_back();
         }
 
         // Итераторы
@@ -127,6 +127,11 @@ namespace saga
             this->back_ = other.back_;
             this->last_ = other.last_;
             this->last_old_ = other.last_old_;
+
+            if(this->back_ == this->last_)
+            {
+                this->tweak_back();
+            }
         }
 
         void rewind_front()
@@ -150,6 +155,7 @@ namespace saga
         constexpr reference back() const
         {
             assert(!!*this);
+            assert(this->back_ != this->last_);
 
             return *this->back_;
         }
@@ -163,7 +169,7 @@ namespace saga
         {
             this->last_ = this->last_old_;
             this->back_ = this->last_;
-            this->tweak_back(typename std::iterator_traits<Sentinel>::iterator_category{});
+            this->tweak_back();
         }
 
         void forget_back()
@@ -200,6 +206,11 @@ namespace saga
         }
 
     private:
+        constexpr void tweak_back()
+        {
+            return this->tweak_back(typename std::iterator_traits<Sentinel>::iterator_category{});
+        }
+
         constexpr void tweak_back(std::input_iterator_tag)
         {}
 

--- a/tests/cursor/subrange.cpp
+++ b/tests/cursor/subrange.cpp
@@ -62,6 +62,14 @@ namespace
     void check_cursor_equal(saga::subrange_cursor<FI, S> const & lhs,
                             saga::subrange_cursor<FI, S> const & rhs)
     {
+        if(lhs == rhs)
+        {
+            CHECK(lhs.begin() == rhs.begin());
+            CHECK(lhs.end() == rhs.end());
+            CHECK(lhs.dropped_front().begin() == rhs.dropped_front().begin());
+            CHECK(lhs.dropped_back().end() == rhs.dropped_back().end());
+        }
+
         CHECK((lhs == rhs)
               == (lhs.begin() == rhs.begin()
                   && lhs.end() == rhs.end()

--- a/tests/cursor/subrange.cpp
+++ b/tests/cursor/subrange.cpp
@@ -157,3 +157,23 @@ TEST_CASE("subrange cursor rebase")
         REQUIRE(result_mutable.dropped_back().end() == dest.end());
     };
 }
+
+TEST_CASE("subrange_cursor::splice, regression #996")
+{
+      saga_test::property_checker << [](std::list<int> const & src)
+      {
+          auto const part2 = saga::make_subrange_cursor(src.end(), src.end(), saga::unsafe_tag_t{});
+          auto const part1 = saga::cursor::all(src);
+
+          auto result = part1;
+          result.splice(part2);
+
+          REQUIRE(!part2);
+          REQUIRE(result == part1);
+
+          if(!src.empty())
+          {
+              REQUIRE(std::addressof(result.back()) == std::addressof(src.back()));
+          }
+      };
+}

--- a/tests/random_engine.hpp
+++ b/tests/random_engine.hpp
@@ -106,8 +106,15 @@ namespace saga_test
         {
             auto const num = saga::cursor::size(cur);
 
-            return saga::cursor::drop_front_n(std::move(cur)
-                                              , saga_test::random_uniform(0, num));
+            auto const pos1 = saga_test::random_uniform(0, num);
+            auto const pos2 = saga_test::random_uniform(0, num);
+
+            auto after = saga::cursor::drop_front_n(std::move(cur), std::max(pos1, pos2));
+            cur = after.dropped_front();
+            after.exhaust_back();
+            cur.splice(after);
+
+            return saga::cursor::drop_front_n(std::move(cur), std::min(pos1, pos2));
         }
 
         template <class Cursor>
@@ -127,6 +134,9 @@ namespace saga_test
     template <class Cursor>
     Cursor random_subcursor_of(Cursor cur)
     {
+        cur.forget_front();
+        cur.forget_back();
+
         return detail::random_subcursor_of(std::move(cur), saga::cursor_category_t<Cursor>{});
     }
 }


### PR DESCRIPTION
Если пришиваемый интервал был пуст, а получившийся нет, то
back_ находился в неправильном состоянии

#996