### PR TITLE
Исправление gcd_extended_euclidean

### DIFF
--- a/include/saga/numeric.hpp
+++ b/include/saga/numeric.hpp
@@ -309,20 +309,28 @@ namespace saga
         IntType second = 0;
     };
 
-    struct extended_gcd_euclidean_fn
+    struct gcd_extended_euclidean_fn
     {
-        template <class IntType1, class IntType2>
-        constexpr
-        extended_gcd_result<std::common_type_t<IntType1, IntType2>>
-        operator()(IntType1 lhs, IntType2 rhs) const
+    private:
+        template <class IntType>
+        static constexpr IntType abs_impl(IntType num)
         {
-            using Result = std::common_type_t<IntType1, IntType2>;
-            auto x_0 = Result(0);
-            auto x_1 = Result(1);
-            auto y_0 = Result(1);
-            auto y_1 = Result(0);
+            return num < 0 ? - num : num;
+        }
 
-            for(; lhs != IntType1(0);)
+        template <class IntType>
+        static constexpr extended_gcd_result<IntType> gcd_impl(IntType lhs, IntType rhs)
+        {
+            static_assert(std::is_signed<IntType>{});
+            assert(lhs >= 0);
+            assert(rhs >= 0);
+
+            auto x_0 = IntType(0);
+            auto x_1 = IntType(1);
+            auto y_0 = IntType(1);
+            auto y_1 = IntType(0);
+
+            for(; lhs != IntType(0);)
             {
                 auto qoutient = rhs / lhs;
                 rhs = saga::exchange(lhs, rhs % lhs);
@@ -331,6 +339,28 @@ namespace saga
             }
 
             return {std::move(rhs), std::move(x_0), std::move(y_0)};
+        }
+
+    public:
+        template <class IntType1, class IntType2>
+        constexpr
+        extended_gcd_result<std::common_type_t<IntType1, IntType2>>
+        operator()(IntType1 lhs, IntType2 rhs) const
+        {
+            using Result = std::common_type_t<IntType1, IntType2>;
+
+            auto result = this->gcd_impl<Result>(this->abs_impl<Result>(lhs)
+                                                ,this->abs_impl<Result>(rhs));
+
+            if(lhs < 0)
+            {
+                result.first = -result.first;
+            }
+            if(rhs < 0)
+            {
+                result.second = -result.second;
+            }
+            return result;
         }
     };
 
@@ -532,7 +562,7 @@ namespace saga
 
     inline constexpr auto const gcd = gcd_fn{};
     inline constexpr auto const lcm = lcm_fn{};
-    inline constexpr auto const extended_gcd_euclidean = extended_gcd_euclidean_fn{};
+    inline constexpr auto const gcd_extended_euclidean = gcd_extended_euclidean_fn{};
 
     inline constexpr auto const mark_eratosthenes_seive = mark_eratosthenes_seive_fn{};
     inline constexpr auto const eratosthenes_seive = eratosthenes_seive_fn{};

--- a/include/saga/numeric.hpp
+++ b/include/saga/numeric.hpp
@@ -356,10 +356,12 @@ namespace saga
             {
                 result.first = -result.first;
             }
+
             if(rhs < 0)
             {
                 result.second = -result.second;
             }
+
             return result;
         }
     };

--- a/tests/ProjectEuler/projectEuler.cpp
+++ b/tests/ProjectEuler/projectEuler.cpp
@@ -1771,8 +1771,8 @@ namespace
         auto fib_str = ::make_fibonacci_sequence(::integer10(1), ::integer10(1))
                      | saga::cursor::transform(to_str);
 
-        auto cur = saga::find_if(std::move(saga::cursor::enumerate(fib_str)),
-                            [&](auto const & elem) {return elem.value.size() >= digits;});
+        auto cur = saga::find_if(std::move(saga::cursor::enumerate(fib_str))
+                                ,[&](auto const & elem) {return elem.value.size() >= digits;});
         assert(!!cur);
 
         return cur.front().index + 1;

--- a/tests/numeric.cpp
+++ b/tests/numeric.cpp
@@ -1090,25 +1090,29 @@ TEST_CASE("gcd : functional object")
 
 TEST_CASE("extended gcd")
 {
-    using Value1 = std::uint32_t;
-    using Value2 = std::uint64_t;
+    using Value1 = std::int32_t;
+    using Value2 = std::int16_t;
+    using Common = std::int64_t;
 
-    static_assert(sizeof(Value2) > sizeof(Value1), "");
-    static_assert(std::is_unsigned<Value1>{});
-    static_assert(std::is_unsigned<Value2>{});
+    static_assert(sizeof(Common) >= 2*sizeof(Value1), "");
+    static_assert(sizeof(Common) >= 2*sizeof(Value2), "");
+    static_assert(std::is_signed<Value1>{});
+    static_assert(std::is_signed<Value2>{});
 
-    saga_test::property_checker <<[](Value1 const & lhs, Value1 const & rhs)
+    saga_test::property_checker <<[](Value1 const & lhs, Value2 const & rhs)
     {
-        auto const result = saga::extended_gcd_euclidean(lhs, Value2(rhs));
+        auto const result = saga::gcd_extended_euclidean(lhs, rhs);
 
-        REQUIRE(result.gcd == saga::gcd(lhs, Value2(rhs)));
-        REQUIRE(result.gcd == result.first * lhs + result.second * rhs);
+        CAPTURE(lhs, rhs, result.gcd, result.first, result.second);
+
+        REQUIRE(result.gcd == saga::gcd(Common(lhs), Common(rhs)));
+        REQUIRE(result.gcd == result.first * Common(lhs) + result.second * Common(rhs));
     };
 
     {
-        constexpr auto lhs = 6;
-        constexpr auto rhs = 10;
-        constexpr auto result = saga::extended_gcd_euclidean(lhs, rhs);
+        constexpr auto lhs = -6;
+        constexpr auto rhs = -10;
+        constexpr auto result = saga::gcd_extended_euclidean(lhs, rhs);
         static_assert(result.gcd == std::gcd(lhs, rhs));
         static_assert(result.gcd == lhs * result.first + rhs * result.second);
     }

--- a/tests/numeric.cpp
+++ b/tests/numeric.cpp
@@ -1090,18 +1090,25 @@ TEST_CASE("gcd : functional object")
 
 TEST_CASE("extended gcd")
 {
-    using Value1 = std::int32_t;
-    using Value2 = std::int16_t;
+    using Source1 = std::int8_t;
+    using Source2 = std::int16_t;
+    using Arg1 = std::int16_t;
+    using Arg2 = std::int32_t;
+
     using Common = std::int64_t;
 
-    static_assert(sizeof(Common) >= 2*sizeof(Value1), "");
-    static_assert(sizeof(Common) >= 2*sizeof(Value2), "");
-    static_assert(std::is_signed<Value1>{});
-    static_assert(std::is_signed<Value2>{});
+    static_assert(sizeof(Arg1) >= 2*sizeof(Source1), "");
+    static_assert(sizeof(Arg2) >= 2*sizeof(Source2), "");
+    static_assert(sizeof(Common) >= 2*sizeof(Arg1), "");
+    static_assert(sizeof(Common) >= 2*sizeof(Arg2), "");
 
-    saga_test::property_checker <<[](Value1 const & lhs, Value2 const & rhs)
+    static_assert(!std::is_same<Arg1, Arg2>{});
+    static_assert(std::is_signed<Arg1>{});
+    static_assert(std::is_signed<Arg2>{});
+
+    saga_test::property_checker <<[](Source1 const & lhs, Source2 const & rhs)
     {
-        auto const result = saga::gcd_extended_euclidean(lhs, rhs);
+        auto const result = saga::gcd_extended_euclidean(Arg1(lhs), Arg2(rhs));
 
         CAPTURE(lhs, rhs, result.gcd, result.first, result.second);
 


### PR DESCRIPTION
* ОШИБКА: От аргументов берётся модуль, теперь gcd всегда неотрицательный
* КРИТИЧЕСКОЕ: Переименован в extended_gcd_euclidean_fn